### PR TITLE
Check if item is in session before expunging

### DIFF
--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -427,7 +427,7 @@ class ModelFormField(FormField):
                 # only delete persistent objects
                 if has_identity(item):
                     sess.delete(item)
-                else:
+                elif item in sess:
                     sess.expunge(item)
                 setattr(obj, name, None)
 


### PR DESCRIPTION
This change makes the code not throw an error when handling an item that has not yet been added to a session. I ran into this problem while writing tests for another project, but I'm not quite sure how to reproduce the issue yet, so I couldn't include a test for this.
