### PR TITLE
Update generator to support python 2.6

### DIFF
--- a/wtforms_alchemy/generator.py
+++ b/wtforms_alchemy/generator.py
@@ -1,5 +1,8 @@
 #import pytz
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 from decimal import Decimal
 from wtforms import (
     BooleanField,


### PR DESCRIPTION
collections.OrderedDict was introduced in python 2.7 so here we offer support for the ordereddict library as an alternative.
