### PR TITLE
Check if excluded key exists before deletion

### DIFF
--- a/wtforms_alchemy/generator.py
+++ b/wtforms_alchemy/generator.py
@@ -163,7 +163,8 @@ class FormGenerator(object):
 
             if self.meta.exclude:
                 for key in self.meta.exclude:
-                    del attrs[key]
+                    if key in attrs:
+                        del attrs[key]
         return attrs
 
     def validate_attribute(self, attr_name):


### PR DESCRIPTION
Otherwise it throws an exceptions if the meta exclude include an extra key which is either already removed or doesn't exists such as 'id' or 'pk'.
