### PR TITLE
Allow non-existent field names in ModelForm Meta exclude

### DIFF
--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -207,6 +207,11 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
             #: List of fields to only include in the generated form.
             only = defaults.pop('only', [])
 
+            #: Silently ignore exclude elements which aren't mapped
+            #:
+            #: By Default silently ignores missing elements
+            silent_exclude = defaults.pop('silent_exclude', True)
+
         def __init__(self, *args, **kwargs):
             """Sets object as form attribute."""
 

--- a/wtforms_alchemy/generator.py
+++ b/wtforms_alchemy/generator.py
@@ -163,7 +163,9 @@ class FormGenerator(object):
 
             if self.meta.exclude:
                 for key in self.meta.exclude:
-                    if key in attrs:
+                    if self.meta.silent_exclude and not key in attrs:
+                        continue
+                    else:
                         del attrs[key]
         return attrs
 


### PR DESCRIPTION
This allows me to add exclude attributes which don't actually exists. I do a lot of dynamic models / classes and this is useful.
