### PR TITLE
Do not overwrite get_session of base class

### DIFF
--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,0 +1,37 @@
+from wtforms_alchemy import model_form_factory, ModelForm
+from wtforms import Form
+from wtforms_test import FormTestCase
+
+
+class TestInheritance(FormTestCase):
+    class Base(Form):
+        @classmethod
+        def get_session(self):
+            return 'TestSession'
+
+    def test_default_base(self):
+        assert ModelForm.get_session is None
+
+    def test_custom_base_without_session(self):
+        cls = model_form_factory(Form)
+        assert cls.get_session is None
+
+    def test_custom_base_with_session(self):
+        cls = model_form_factory(self.Base)
+        assert cls.get_session() == 'TestSession'
+
+    def test_inherit_with_new_session(self):
+        cls = model_form_factory(self.Base)
+
+        class Sub(cls):
+            @classmethod
+            def get_session(self):
+                return 'SubTestSession'
+        assert Sub.get_session() == 'SubTestSession'
+
+    def test_inherit_without_new_session(self):
+        cls = model_form_factory(self.Base)
+
+        class Sub(cls):
+            pass
+        assert Sub.get_session() == 'TestSession'

--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -85,7 +85,9 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
         Flask-SQLAlchemy along with WTForms-Alchemy you don't need to
         set this.
         """
-        get_session = None
+
+        if not hasattr(base, 'get_session'):
+            get_session = None
 
         class Meta:
             model = None


### PR DESCRIPTION
I encountered this problem while working with a custom base class. Since I define all my behaviour in it and directly subclass from the `ModelForm` the factory spits out, I created `get_session` there but this code overwrote it.

All tests pass on my end. Not familiar enough with the code base to determine if I should add a test for this. If a test should be added, please tell me where, as I just started using your library.

Note that this relies on the assumption that only a single base class is used (which is true for the current code, but I don't know about future plans).
