### PR TITLE
Remove the need for psycopg2 in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-before_script:
-  - psql -c 'create database wtforms_alchemy_test;' -U postgres
-
-
 language: python
 python:
   - 2.6

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ extras_require = {
         'Jinja2>=2.3',
         'docutils>=0.10',
         'flexmock>=0.9.7',
-        'psycopg2>=2.4.6',
         'WTForms-Test>=0.1.1'
     ],
     'babel': ['Babel>=1.3'],

--- a/tests/test_field_exclusion.py
+++ b/tests/test_field_exclusion.py
@@ -23,7 +23,6 @@ class TestFieldExclusion(ModelFormTestCase):
 
 
 class TestTSVectorType(ModelFormTestCase):
-    dns = 'postgres://postgres@localhost/wtforms_alchemy_test'
 
     def test_does_not_include_tsvector_typed_columns_with_default(self):
         self.init(TSVectorType)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -249,7 +249,6 @@ class TestModelColumnToFormFieldTypeConversion(ModelFormTestCase):
 
 
 class TestWeekDaysTypeConversion(ModelFormTestCase):
-    dns = 'postgres://postgres@localhost/wtforms_alchemy_test'
 
     def test_weekdays_type_converts_to_weekdays_field(self):
         self.init(type_=WeekDaysType)


### PR DESCRIPTION
Doesn't seem to be used or necessary anywhere, AFAICT.
