### PR TITLE
Don't merge: Bug with sa-defaults and auto_now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ extras_require = {
         'docutils>=0.10',
         'flexmock>=0.9.7',
         'psycopg2>=2.4.6',
+        'sqlalchemy-defaults',
         'WTForms-Test>=0.1.1'
     ],
     'babel': ['Babel>=1.3'],

--- a/tests/test_sqlalchemy_defaults_integration.py
+++ b/tests/test_sqlalchemy_defaults_integration.py
@@ -1,0 +1,25 @@
+from tests import ModelFormTestCase
+from sqlalchemy_defaults import Column, make_lazy_configured
+import sqlalchemy as sa
+
+class TestSQLAlchemyDefaults(ModelFormTestCase):
+
+    def init_model(self, type_=sa.Unicode(255), **kwargs):
+        """ Uses sqlalchemy_defaults.Column instead of sa.Column. """
+        kwargs.setdefault('nullable', False)
+
+        class ModelTest(self.base):
+            __tablename__ = 'model_test'
+            __lazy_options__ = {}
+            query = None
+            id = Column(sa.Integer, primary_key=True)
+            test_column = Column(type_, **kwargs)
+            some_property = 'something'
+
+        self.ModelTest = ModelTest
+
+    def test_auto_now(self):
+        make_lazy_configured(sa.orm.mapper)
+        self.init(sa.DateTime, auto_now=True)
+        print self.base.metadata.sorted_tables
+        assert "Got here"


### PR DESCRIPTION
Bug occurs when used in conjunction with sqlalchemy-defaults, and was
introduced by ca119b08f.

Wasn't sure whether to report it here or to sqlalchemy-defaults, but since the bug was introduced here I though it might get fixed here as well. This was working with the latest version of sa-defaults and wtforms-alchemy 0.8.5, but broke on the update to 0.8.6 (the single commit mentioned above).

As I'm not really sure what's going on I haven't been able to find a fix that doesn't break all the other test cases, I hope you can come up with something, @kvesteri. Not sure if you want to include sa-defaults to run the test eventually, but it was the easiest way to replicate the issue.
