### PR TITLE
All classes should extend from object

### DIFF
--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -147,7 +147,7 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
         if not hasattr(base, 'get_session'):
             get_session = None
 
-        class Meta:
+        class Meta(object):
             model = None
 
             default = None
@@ -289,13 +289,13 @@ class ModelCreateForm(ModelForm):
 
 
 class ModelUpdateForm(ModelForm):
-    class Meta:
+    class Meta(object):
         all_fields_optional = True
         assign_required = False
 
 
 class ModelSearchForm(ModelForm):
-    class Meta:
+    class Meta(object):
         all_fields_optional = True
         only_indexed_fields = True
         include_primary_keys = True


### PR DESCRIPTION
After installing WTForms-Alchemy latest version I was getting a stack trace resulting in this error:

```
Traceback (most recent call last):
  File "/home/chris/.virtualenvs/SOON_/bin/manage.py", line 9, in <module>
    load_entry_point('soon==2014.06.11.1', 'console_scripts', 'manage.py')()
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/pkg_resources.py", line 2431, in load_entry_point
    return ep.load()
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/pkg_resources.py", line 2147, in load
    ['__name__'])
  File "/home/chris/Projects/SOON_/SOON/soon/manage.py", line 22, in <module>
    app = create_app()
  File "/home/chris/Projects/SOON_/SOON/soon/loader.py", line 206, in create_app
    register_extenstions(app)
  File "/home/chris/Projects/SOON_/SOON/soon/loader.py", line 127, in register_extenstions
    from soon.views.admin.home import AdminHomeView
  File "/home/chris/Projects/SOON_/SOON/soon/views/admin/home.py", line 13, in <module>
    from soon.auth.forms import AuthenticationForm
  File "/home/chris/Projects/SOON_/SOON/soon/auth/forms.py", line 15, in <module>
    from wtforms_alchemy import model_form_factory
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/wtforms_alchemy/__init__.py", line 281, in <module>
    ModelForm = model_form_factory(Form)
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/wtforms_alchemy/__init__.py", line 133, in model_form_factory
    class ModelForm(six.with_metaclass(meta, base)):
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/six.py", line 713, in __new__
    return meta(name, bases, d)
  File "/home/chris/.virtualenvs/SOON_/local/lib/python2.7/site-packages/wtforms_alchemy/__init__.py", line 102, in __init__
    cls.Meta = type('Meta', tuple(bases), {})
TypeError: Error when calling the metaclass bases
    a new-style class can't have only classic bases
```

After a bit of digging I realised that the `Meta` classes don't extend from object, which is not valid.

I made this fix in my local virtualenv and updated my projects form `Meta` classes to extend from `object` and appears to have fixed the problem.

Thanks,

Chris
