### PR TITLE
Typo in instructions for Flask

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -69,4 +69,4 @@ The you can use the ModelForm just like before:
 
     class UserForm(ModelForm):
         class Meta:
-            model User
+            model = User


### PR DESCRIPTION
Missing = between model and User.
