### PR TITLE
Add include_relationships option to autogenerate query select fields from model relationships.

### DIFF
--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,0 +1,84 @@
+import sqlalchemy as sa
+from wtforms.fields import FormField
+from wtforms_components import PassiveHiddenField
+
+from tests import ModelFormTestCase, MultiDict
+from wtforms_alchemy import ModelFieldList, ModelForm
+from wtforms_alchemy.fields import QuerySelectField, QuerySelectMultipleField
+
+
+class ModelFieldListTestCase(ModelFormTestCase):
+    def create_models(self):
+        class Event(self.base):
+            __tablename__ = 'event'
+            id = sa.Column(sa.Integer, primary_key=True)
+            name = sa.Column(sa.Unicode(255), nullable=False)
+
+        class Location(self.base):
+            __tablename__ = 'location'
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255), nullable=True)
+
+            event_id = sa.Column(sa.Integer, sa.ForeignKey(Event.id))
+            event = sa.orm.relationship(Event, backref='locations')
+
+        self.Event = Event
+        self.Location = Location
+
+
+class TestNoIncludeRelationships(ModelFieldListTestCase):
+    def test_no_include_relationships_many_to_one(self):
+        self.create_models()
+        self.ModelTest = self.Location
+
+        class ModelTestForm(ModelForm):
+            class Meta:
+                model = self.ModelTest
+
+        self.form_class = ModelTestForm
+
+        assert not self.has_field('event')
+
+    def test_no_include_relationships_one_to_many(self):
+        self.create_models()
+        self.ModelTest = self.Event
+
+        class ModelTestForm(ModelForm):
+            class Meta:
+                model = self.ModelTest
+
+        self.form_class = ModelTestForm
+
+        assert not self.has_field('locations')
+
+
+class TestIncludeRelationships(ModelFieldListTestCase):
+    def test_include_relationships_many_to_one(self):
+        self.create_models()
+        self.ModelTest = self.Location
+
+        class ModelTestForm(ModelForm):
+            class Meta:
+                include_relationships = True
+                model = self.ModelTest
+
+        self.form_class = ModelTestForm
+
+        assert self.has_field('event')
+        field = self._make_form().event
+        assert isinstance(field, QuerySelectField)
+
+    def test_include_relationships_one_to_many(self):
+        self.create_models()
+        self.ModelTest = self.Event
+
+        class ModelTestForm(ModelForm):
+            class Meta:
+                include_relationships = True
+                model = self.ModelTest
+
+        self.form_class = ModelTestForm
+
+        assert self.has_field('locations')
+        field = self._make_form().locations
+        assert isinstance(field, QuerySelectMultipleField)

--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -187,6 +187,14 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
             #: form.
             include_foreign_keys = defaults.pop('include_foreign_keys', False)
 
+            #: Whether or not to include relationships. By default this is
+            #: False. When set to True will use query select field for many
+            #: to one relationships and query multiple select field for
+            #: one to many and many to many.
+            #: See relationship_map for overrides
+            include_relationships = defaults.pop(
+                'include_relationships', False)
+
             #: Whether or not to strip string fields
             strip_string_fields = defaults.pop('strip_string_fields', False)
 
@@ -268,6 +276,11 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
             #: Using this configuration option one can easily configure the
             #: type conversion in class level.
             type_map = defaults.pop('type_map', ClassMap())
+
+            #: Dictionary of SQLAlchemy RelationshipProperty direction
+            #: (MANYTOONE, ONETOMANY, MANYTOMANY from sqalchemy.orm.interfaces)
+            #: and WTForms field classes as values.
+            relationship_map = defaults.pop('relationship_map', {})
 
             #: Whether or not to raise InvalidAttributExceptions when invalid
             #: attribute names are given for include / exclude or only


### PR DESCRIPTION
As the title says add `include_relationships` options to reflect `QuerySelectField` and `QuerySelectMultipleField` from model relationships. Also add a relationship_map to configure field class from relation directions.

Only relations with one local column are taken in account.

Please review / tell me what you think about this.

Thanks for this nice library.