### PR TITLE
Add support for empty Meta.only

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -118,6 +118,17 @@ class TestModelFormConfiguration(ModelFormTestCase):
         form = ModelTestForm()
         assert len(form._fields) == 1
 
+    def test_empty_only_attribute(self):
+        self.init()
+
+        class ModelTestForm(ModelForm):
+            class Meta:
+                model = self.ModelTest
+                only = []
+
+        form = ModelTestForm()
+        assert len(form._fields) == 0
+
     def test_supports_field_overriding(self):
         self.init()
 

--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -280,7 +280,7 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
             exclude = defaults.pop('exclude', [])
 
             #: List of fields to only include in the generated form.
-            only = defaults.pop('only', [])
+            only = defaults.pop('only', None)
 
         def __init__(self, *args, **kwargs):
             """Sets object as form attribute."""

--- a/wtforms_alchemy/generator.py
+++ b/wtforms_alchemy/generator.py
@@ -158,7 +158,7 @@ class FormGenerator(object):
 
         :param attrs: Set of attributes
         """
-        if self.meta.only:
+        if self.meta.only is not None:
             attrs = OrderedDict([
                 (key, prop)
                 for key, prop in map(self.validate_attribute, self.meta.only)


### PR DESCRIPTION
Before configuration parameter only = [] was same as no only parameter.
Changed to be same as exclude everything.

This is a breaking change. Some developers might depend on old functionality.
