### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Tools for creating WTForms forms from SQLAlchemy models
 Resources
 ---------
 
-- `Documentation <http://wtforms-alchemy.readthedocs.org/>`_
+- `Documentation <https://wtforms-alchemy.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/kvesteri/wtforms-alchemy/issues>`_
 - `Code <http://github.com/kvesteri/wtforms-alchemy/>`_
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -219,7 +219,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None,
-                       'http://wtforms.readthedocs.org/en/latest/': None,
-                       'https://sqlalchemy-utils.readthedocs.org/en/latest/': None,
-                       'http://wtforms-components.readthedocs.org/en/latest/': None,
+                       'https://wtforms.readthedocs.io/en/latest/': None,
+                       'https://sqlalchemy-utils.readthedocs.io/en/latest/': None,
+                       'https://wtforms-components.readthedocs.io/en/latest/': None,
                       }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ based forms. Strongly influenced by Django ModelForm.
 
 
 
-.. _`SQLAlchemy-Utils ChoiceType`: http://sqlalchemy-utils.readthedocs.org/en/latest/#choicetype
-.. _`SQLAlchemy-Defaults`: https://sqlalchemy-defaults.readthedocs.org/en/latest/
-.. _`Flask-WTF`: https://flask-wtf.readthedocs.org/en/latest/
+.. _`SQLAlchemy-Utils ChoiceType`: https://sqlalchemy-utils.readthedocs.io/en/latest/#choicetype
+.. _`SQLAlchemy-Defaults`: https://sqlalchemy-defaults.readthedocs.io/en/latest/
+.. _`Flask-WTF`: https://flask-wtf.readthedocs.io/en/latest/
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.