### PR TITLE
Support for Enum ChoiceTypes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ def get_version():
 
 extras_require = {
     'test': [
+        'enum34',
         'pytest>=2.3',
         'Pygments>=1.2',
         'Jinja2>=2.3',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -44,11 +44,14 @@ from wtforms_alchemy import (
 )
 from wtforms_alchemy.utils import ClassMap
 
-passlib = None
 try:
     import passlib  # noqa
 except ImportError:
-    pass
+    passlib = None
+try:
+    from enum import Enum
+except ImportError:
+    Enum = None
 
 
 class UnknownType(sa.types.UserDefinedType):
@@ -249,6 +252,35 @@ class TestModelColumnToFormFieldTypeConversion(ModelFormTestCase):
         self.init(type_=ChoiceType(choices))
         self.assert_type('test_column', SelectField)
         model = self.ModelTest(test_column=u'2')
+        form = self.form_class(obj=model)
+        assert '<option selected value="2">' in str(form.test_column)
+
+    @mark.xfail('Enum is None')
+    def test_choice_type_with_enum(self):
+        class Choice(Enum):
+            choice1 = 1
+            choice2 = 2
+
+            def __str__(self):
+                return self.name
+        self.init(type_=ChoiceType(Choice))
+        self.assert_type('test_column', SelectField)
+        assert self.form_class().test_column.choices == [
+            (1, u'choice1'), (2, u'choice2')]
+
+    @mark.xfail('Enum is None')
+    @mark.parametrize(['type_', 'impl'],
+                      [(int, sa.Integer()), (str, sa.String())])
+    def test_choice_type_with_enum_uses_custom_coerce_func(self, type_, impl):
+        class Choice(Enum):
+            choice1 = type_(1)
+            choice2 = type_(2)
+
+            def __str__(self):
+                return self.name
+        self.init(type_=ChoiceType(Choice, impl=impl))
+        self.assert_type('test_column', SelectField)
+        model = self.ModelTest(test_column=type_(2))
         form = self.form_class(obj=model)
         assert '<option selected value="2">' in str(form.test_column)
 

--- a/wtforms_alchemy/generator.py
+++ b/wtforms_alchemy/generator.py
@@ -2,6 +2,10 @@ try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
+try:
+    from enum import Enum
+except ImportError:
+    Enum = None
 import inspect
 from decimal import Decimal
 
@@ -438,7 +442,16 @@ class FormGenerator(object):
         kwargs = {}
         kwargs['coerce'] = self.coerce(column)
         if isinstance(column.type, types.ChoiceType):
-            kwargs['choices'] = column.type.choices
+            choices = column.type.choices
+            if (
+                Enum is not None and
+                isinstance(choices, type)
+                and issubclass(choices, Enum)
+            ):
+                kwargs['choices'] = [
+                    (choice.value, str(choice)) for choice in choices]
+            else:
+                kwargs['choices'] = choices
         elif 'choices' in column.info and column.info['choices']:
             kwargs['choices'] = column.info['choices']
         else:

--- a/wtforms_alchemy/utils.py
+++ b/wtforms_alchemy/utils.py
@@ -10,6 +10,10 @@ try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
+try:
+    from enum import Enum
+except ImportError:
+    Enum = None
 
 
 def choice_type_coerce_factory(type_):
@@ -19,11 +23,21 @@ def choice_type_coerce_factory(type_):
 
     :param type_: ChoiceType object
     """
+    choices = type_.choices
+    if (
+        Enum is not None and
+        isinstance(choices, type)
+        and issubclass(choices, Enum)
+    ):
+        key, choice_cls = 'value', choices
+    else:
+        key, choice_cls = 'code', Choice
+
     def choice_coerce(value):
         if value is None:
             return None
-        if isinstance(value, Choice):
-            return value.code
+        if isinstance(value, choice_cls):
+            return getattr(value, key)
         return type_.python_type(value)
     return choice_coerce
 


### PR DESCRIPTION
Fixes #112 

The user needs to override `__str__` for showing display labels.

One other issue I encountered was that the `impl` argument needs to be an instance whenever supplied. That's probably not a wtf-alchemy issue. Not sure which package should handle it.