### PR TITLE
Fix get_pk_from_identity

### DIFF
--- a/wtforms_alchemy/fields.py
+++ b/wtforms_alchemy/fields.py
@@ -314,7 +314,7 @@ class QuerySelectMultipleField(QuerySelectField):
 
 
 def get_pk_from_identity(obj):
-    cls, key = identity_key(instance=obj)
+    cls, key = identity_key(instance=obj)[0:2]
     return ':'.join(text_type(x) for x in key)
 
 


### PR DESCRIPTION
With SQLAlchemy 1.2, `sqlalchemy.orm.utils.identity_key()` returns three values instead of two.

This ensures we use only the first two (which remained the same).

Fixes #127 