### PR TITLE
Fix issue #86

### DIFF
--- a/tests/test_unique_validator.py
+++ b/tests/test_unique_validator.py
@@ -334,11 +334,6 @@ class TestUniqueValidator(object):
                 filter_by(name=u'someone').first()
 
         form = MyForm(obj=obj)
-        # form = myform(multidict({
-        #     'name': u'someone',
-        #     'email': u'second.email@example.com',
-        #     'favorite_color': str(red_color.id)
-        # }))
         form.validate()
         assert form.errors != {'name': [u'already exists.']}
 

--- a/tests/test_unique_validator.py
+++ b/tests/test_unique_validator.py
@@ -241,7 +241,7 @@ class TestUniqueValidator(object):
         form.validate()
         assert form.errors == {'name': [u'Already exists.']}
 
-    def test_existing_name_collision_classical_mapping_when_updating(self):
+    def test_existing_name_collision_classical_mapping_when_updating_object(self):
         sa.Table(
             'user',
             sa.MetaData(None),
@@ -304,7 +304,7 @@ class TestUniqueValidator(object):
         form.validate()
         assert form.errors == {'name': [u'Already exists.']}
 
-    def test_relationship_multiple_collision_when_updating(self):
+    def test_relationship_multiple_collision_when_updating_object(self):
         class MyForm(ModelForm):
             id = HiddenField('id')
             name = TextField(

--- a/wtforms_alchemy/validators.py
+++ b/wtforms_alchemy/validators.py
@@ -1,7 +1,7 @@
 from collections import Iterable, Mapping
 
 import six
-from sqlalchemy import Column
+from sqlalchemy import Column, inspect
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from wtforms import ValidationError
 
@@ -25,6 +25,10 @@ class Unique(object):
         parameter.
     :param message:
         The error message.
+
+    When you are updating an existing object using a form the primary key field must be
+    included in the form.
+    e.g. id = HiddenField('id')
     """
     field_flags = ('unique', )
 
@@ -85,7 +89,17 @@ class Unique(object):
                 "ModelForm or make this attribute available in your form."
             )
 
-        if obj and not form._obj == obj:
-            if self.message is None:
-                self.message = field.gettext(u'Already exists.')
-            raise ValidationError(self.message)
+        is_update = False
+        pkeys = inspect(self.model).primary_key
+        for pk in pkeys:
+            form_has_pk = getattr(form._obj, pk.name, None)
+            if form_has_pk:
+                pk1 = pk.type.python_type(getattr(obj, pk.name, None))
+                pk2 = pk.type.python_type(getattr(form._obj, pk.name, None))
+                is_update = pk1 == pk2
+
+        if not is_update:
+            if obj and not form._obj == obj:
+                if self.message is None:
+                    self.message = field.gettext(u'Already exists.')
+                raise ValidationError(self.message)


### PR DESCRIPTION
I think this fixes issues #116 and #86. 
The Unique validator now determines if the object referenced by the form refers to the same object containing the non-unique columns. If the objects reference the same persistent item the submitted values are not considered to be non-unique.