### PR TITLE
Mistake on Phonenumber type documentation.

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -293,7 +293,7 @@ Now the UserForm is essentially the same as:
 
     class UserForm(Form):
         name = TextField(validators=[DataRequired(), Length(max=100)])
-        password = PhoneNumberField(validators=[DataRequired()])
+        phone_number = PhoneNumberField(validators=[DataRequired()])
 
 
 URL type


### PR DESCRIPTION
There was an mistake on Phonenumber type documentation: The fieldname password was used instead of phone_number.