### PR TITLE
Unique validator does not raises 500 when it requires a type coercion and it raises an exception

### DIFF
--- a/tests/test_query_select_field.py
+++ b/tests/test_query_select_field.py
@@ -101,6 +101,15 @@ class TestQuerySelectField(TestBase):
         assert not form.validate()
         assert form.a.errors, ['Not a valid choice']
 
+        # Test query with no results
+        form = F()
+        form.a.query = (
+            sess.query(self.Test)
+            .filter(self.Test.id == 1, self.Test.id != 1)
+            .all()
+        )
+        assert form.a() == []
+
     def test_with_query_factory(self):
         sess = self.Session()
         self._fill(sess)
@@ -127,6 +136,15 @@ class TestQuerySelectField(TestBase):
             ('hello2', 'banana', False)
         ]
         assert not form.validate()
+
+        # Test query with no results
+        form = F()
+        form.a.query = (
+            sess.query(self.Test)
+            .filter(self.Test.id == 1, self.Test.id != 1)
+            .all()
+        )
+        assert form.a() == []
 
         form = F(DummyPostData(a=['1'], b=['hello2']))
         assert form.a.data.id == 1
@@ -206,6 +224,16 @@ class TestQuerySelectMultipleField(TestBase):
         assert [v.id for v in form.a.data], [2]
         assert form.a(), [('1', 'apple', False), ('2', 'banana', True)]
         assert form.validate()
+
+    def test_empty_query(self):
+        # Test query with no results
+        form = self.F()
+        form.a.query = (
+            self.sess.query(self.Test)
+            .filter(self.Test.id == 1, self.Test.id != 1)
+            .all()
+        )
+        assert form.a() == []
 
 
 class DatabaseTestCase(object):

--- a/tests/test_unique_validator.py
+++ b/tests/test_unique_validator.py
@@ -1,12 +1,14 @@
 import sqlalchemy as sa
-from pytest import mark, raises
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from sqlalchemy_utils import PhoneNumberType
 from wtforms import Form
 from wtforms.fields import TextField
+from wtforms_alchemy import (ModelForm, PhoneNumberField, QuerySelectField,
+                             Unique)
 
+from pytest import mark, raises
 from tests import MultiDict
-from wtforms_alchemy import ModelForm, QuerySelectField, Unique
 
 base = declarative_base()
 
@@ -22,6 +24,10 @@ class User(base):
     id = sa.Column(sa.Integer, primary_key=True)
     name = sa.Column(sa.Unicode(255), unique=True)
     email = sa.Column(sa.Unicode(255))
+    phone = sa.Column(
+        PhoneNumberType(region='ES', max_length=25),
+        unique=True
+    )
     favorite_color_id = sa.Column(sa.Integer, sa.ForeignKey(Color.id))
     favorite_color = relationship(Color)
 
@@ -372,3 +378,16 @@ class TestUniqueValidator(object):
 
         form = MyForm(MultiDict({'name': u'someone'}))
         assert form.validate()
+
+    def test_invalid_unique_phone_no_500_error(self):
+        class MyForm(ModelForm):
+            phone = PhoneNumberField(
+                validators=[Unique(User.phone)],
+                region='ES'
+            )
+
+        form = MyForm(MultiDict({'phone': u'abc$%·'}))
+        form.validate()
+        assert len(form.errors['phone']) == 2
+        assert 'Not a valid phone number value' in form.errors['phone']
+        assert 'Unable to check uniqueness.' in form.errors['phone']

--- a/wtforms_alchemy/validators.py
+++ b/wtforms_alchemy/validators.py
@@ -25,13 +25,18 @@ class Unique(object):
         parameter.
     :param message:
         The error message.
+    :param message_uncheck
+        The error message when the attempt to check uniqueness cannot be
+        carried out, i.e. the query throws an exception.
     """
     field_flags = ('unique', )
 
-    def __init__(self, column, get_session=None, message=None):
+    def __init__(self, column, get_session=None, message=None,
+                 message_uncheck=u'Unable to check uniqueness.'):
         self.column = column
         self.message = message
         self.get_session = get_session
+        self.message_uncheck = message_uncheck
 
     @property
     def query(self):
@@ -76,7 +81,10 @@ class Unique(object):
         for field_name, column in columns:
             query = query.filter(column == form[field_name].data)
 
-        obj = query.first()
+        try:
+            obj = query.first()
+        except:
+            raise ValidationError(self.message_uncheck)
 
         if not hasattr(form, '_obj'):
             raise Exception(


### PR DESCRIPTION
On issue #139 I presented an scenario where unique causes 500 errors because the query to check for uniquenes cannot be performed due to a failed type coercion with PhoneNumberType and phonenumbers.

This pull request with its associated test solves this issue using a reviewed version of the restrictive approach that I proposed. Though it is not perfect, nothing better comes to my mind. If the unique validation cannot be performed, no matter the reason, there is a ValidationError with a customizable message through a new parameter of the Unique validator called message_uncheck. By default, it is set to show the message "Unable to check uniqueness." This causes validation errors instead of 500 errors when invalid data is set on unique fields that require a typer coercion that might raise exceptions.