### PR TITLE
Drop support for Python 3.8 and earlier 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
-        tox_env: ['sqlalchemy14']
+        python-version: ["3.9"]
+        tox_env: ["sqlalchemy14"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Changelog
 
 Here you can see the full list of changes between each WTForms-Alchemy release.
 
+Unreleased
+^^^^^^^^^^
+
+- Dropped support for Python 3.8 and earlier. The minimum supported Python version is now 3.9.
 
 0.18.0 (2021-12-21)
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -47,7 +47,7 @@ Installation
 
 
 
-The supported python versions are 2.6, 2.7 and 3.3.
+The supported Python versions are 3.9.
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     platforms='any',
     install_requires=[
         'SQLAlchemy>=1.0',
-        'WTForms>=2.2',
+        'WTForms>=2.2,<=3.0.0',
         'WTForms-Components>=0.9.2',
         'SQLAlchemy-Utils>=0.32.6'
     ],

--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py39
 
 [testenv]
 deps =


### PR DESCRIPTION
The minimum supported Python version is now 3.9.
