### PR TITLE
Dropped support for SQLAlchemy 1.3 and earlier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ^^^^^^^^^^
 
 - Dropped support for Python 3.8 and earlier. The minimum supported Python version is now 3.9.
+- Dropped support for SQLAlchemy 1.3 and earlier. The minimum supported SQLAlchemy version is now 1.4.
 
 0.18.0 (2021-12-21)
 ^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'SQLAlchemy>=1.0',
+        'SQLAlchemy>=1.4',
         'WTForms>=2.2,<=3.0.0',
         'WTForms-Components>=0.9.2',
         'SQLAlchemy-Utils>=0.32.6'

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py39
 deps =
     .[test_all]
     pytest-cov
-    sqlalchemy13: SQLAlchemy[postgresql_pg8000]>=1.3,<1.4
     sqlalchemy14: SQLAlchemy>=1.4,<1.5
 commands = pip install -e ".[test]"
            py.test


### PR DESCRIPTION
The minimum supported SQLAlchemy version is now 1.4.