### PR TITLE
Remove WTForms 1 check from tests

### DIFF
--- a/tests/test_model_form_factory.py
+++ b/tests/test_model_form_factory.py
@@ -1,5 +1,3 @@
-from distutils.version import LooseVersion
-
 import wtforms
 from pytest import raises
 from wtforms import Form
@@ -91,9 +89,6 @@ class TestModelFormFactory(ModelFormTestCase):
         assert form.Meta.unique_validator is None
 
     def test_class_meta_wtforms2(self):
-        if LooseVersion(wtforms.__version__) < LooseVersion('2'):
-            return  # skip test for wtforms < 2
-
         self.init()
 
         class SomeForm(Form):


### PR DESCRIPTION
This check is no longer needed as WTForms 1 is no longer supported.

Fixes #161