### PR TITLE
Bump SQLAlchemy-Utils requirement to >=0.40.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'SQLAlchemy>=1.4',
         'WTForms>=3.1.0',
         'WTForms-Components>=0.11.0',
-        'SQLAlchemy-Utils>=0.32.6'
+        'SQLAlchemy-Utils>=0.40.0'
     ],
     extras_require=extras_require,
     classifiers=[


### PR DESCRIPTION
This is the first SQLAlchemy-Utils release that supports SQLAlchemy 2.0.