### PR TITLE
remove broken Python2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ Generates WTForms forms from SQLAlchemy models.
 
 import os
 import re
-import sys
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ import sys
 from setuptools import setup
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-PY3 = sys.version_info[0] == 3
 
 
 def get_version():
@@ -41,7 +40,6 @@ extras_require = {
     "password": ["passlib >= 1.6, < 2.0"],
     "color": ["colour>=0.0.4"],
     "i18n": ["SQLAlchemy-i18n >= 0.8.2"],
-    "ipaddress": ["ipaddr"] if not PY3 else [],
     "timezone": ["python-dateutil"],
 }
 

--- a/tests/test_select_field.py
+++ b/tests/test_select_field.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 
-import six
 import sqlalchemy as sa
 from wtforms_components import SelectField
 
@@ -69,11 +68,11 @@ class TestSelectFieldCoerce(ModelFormTestCase):
         self.init(type_=sa.Unicode(255), info={"choices": choices})
         form = self.form_class(MultiDict({"test_column": "2.0"}))
         assert form.test_column.data == "2.0"
-        assert isinstance(form.test_column.data, six.text_type)
+        assert isinstance(form.test_column.data, str)
 
     def test_unicode_text_coerces_values_to_unicode_strings(self):
         choices = [("1.0", "1.0"), ("2.0", "2.0")]
         self.init(type_=sa.UnicodeText, info={"choices": choices})
         form = self.form_class(MultiDict({"test_column": "2.0"}))
         assert form.test_column.data == "2.0"
-        assert isinstance(form.test_column.data, six.text_type)
+        assert isinstance(form.test_column.data, str)


### PR DESCRIPTION
Hi,

After update of wtforms-components that removed Python2 support, our CI for wtfomrs-alchemy started failing because of an undeclared dependecy on six. Please allign with wtforms-components.

https://tracker.debian.org/pkg/wtforms-components

Greetings