### PR TITLE
Fix empty list ignored for Meta.only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 
 Here you can see the full list of changes between each WTForms-Alchemy release.
 
+0.19.1 (2025-08-11)
+^^^^^^^^^^^^^^^^^^^
+
+- Fixed issue where empty list was ignored for the ``only`` meta parameter of ``ModelForm``.
+
 0.19.0 (2024-11-18)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -121,6 +121,17 @@ class TestModelFormConfiguration(ModelFormTestCase):
         form = ModelTestForm()
         assert len(form._fields) == 1
 
+    def test_empty_only_attribute(self):
+        self.init()
+
+        class ModelTestForm(ModelForm):
+            class Meta:
+                model = self.ModelTest
+                only = []
+
+        form = ModelTestForm()
+        assert len(form._fields) == 0
+
     def test_supports_field_overriding(self):
         self.init()
 

--- a/wtforms_alchemy/__init__.py
+++ b/wtforms_alchemy/__init__.py
@@ -266,7 +266,7 @@ def model_form_factory(base=Form, meta=ModelFormMeta, **defaults):
             exclude = defaults.pop("exclude", [])
 
             #: List of fields to only include in the generated form.
-            only = defaults.pop("only", [])
+            only = defaults.pop("only", None)
 
         def __init__(self, *args, **kwargs):
             """Sets object as form attribute."""

--- a/wtforms_alchemy/generator.py
+++ b/wtforms_alchemy/generator.py
@@ -160,7 +160,7 @@ class FormGenerator:
 
         :param attrs: Set of attributes
         """
-        if self.meta.only:
+        if self.meta.only is not None:
             attrs = OrderedDict(
                 [
                     (key, prop)


### PR DESCRIPTION
Before configuration parameter `only = []` was same as no `only` parameter. Changed to be same as exclude everything.