### PR TITLE
Prepare for wtforms 3.3 support

### DIFF
--- a/wtforms_alchemy/fields.py
+++ b/wtforms_alchemy/fields.py
@@ -56,6 +56,7 @@ class ModelFieldList(FieldList):
         field = self._get_bound_field_for_entry(
             formdata=formdata, data=data, index=index
         )
+        field.index = self.last_index
         if data != unset_value and data:
             if formdata:
                 field.process(formdata)


### PR DESCRIPTION
wtforms 3.3 added FieldList._compact_indices which reads entry.index during process(); ModelFieldList._add_entry overrides FieldList._add_entry without setting the attribute, causing AttributeError.

fix #179 