### PR TITLE
Fix WTForms version specifiers in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ deps =
     pytest-cov
     sqlalchemy1.4: SQLAlchemy~=1.4
     sqlalchemy2.0: SQLAlchemy~=2.0
-    wtforms3.1: WTForms~=3.1
-    wtforms3.2: WTForms~=3.2
+    wtforms3.1: WTForms~=3.1.0
+    wtforms3.2: WTForms~=3.2.0
 commands = pip install -e ".[test]"
            py.test
 install_command = pip install {packages}


### PR DESCRIPTION
`~=3.1` is equivalent to `>=3.1,==3.*` whereas the intention was to match `3.1` series only. Add additional zero to the version specifier to make it more specific.